### PR TITLE
Update urls on dataset create page along with removing text

### DIFF
--- a/ckanext/portalopendatadk/templates/package/snippets/resource_form.html
+++ b/ckanext/portalopendatadk/templates/package/snippets/resource_form.html
@@ -42,11 +42,7 @@
   {{ form.errors(error_summary) }}
 
   <input name="id" value="{{ data.id }}" type="hidden"/>
-  <div class="control-group ">
-    <div class="controls" style="font-weight: bold;font-size:14px">
-       Bemærk! Dit datasæt cpr-scannes ved offentliggørelse. Der kan derfor gå op til 5 min. før, dit datasæt er synligt på <a href="http://www.portal.opendata.dk">www.portal.opendata.dk</a>      
-    </div>
-  </div>
+  
   {% block basic_fields %}
     {% block basic_fields_url %}
       {% set is_upload = (data.url_type == 'upload') %}
@@ -92,8 +88,8 @@
     <div class="controls">
       <label class="checkbox" for="field-cpr" onClick="checkBoxClick()">
         <input id="field-cpr" type="checkbox" name="cpr" value=""   />
-        Ved upload af data garanterer jeg, at jeg er indforstået med de gældende vilkår og betingelser på <a href="http://www.portal.opendata.dk" target="_blank">www.portal.opendata.dk</a> - heriblandt at data ikke indeholder følsomme personoplysninger eller personhenførbare informationer.<br/><br/>
-        Læs mere under <a href="http://www.portal.opendata.dk/vilkaar-og-betingelser.pdf" target="_blank">Gældende vilkår og betingelser.</a> 
+        Ved upload af data garanterer jeg, at jeg er indforstået med de gældende vilkår og betingelser på <a href="http://www.portal.opendata.dk" target="_blank">www.opendata.dk</a> - heriblandt at data ikke indeholder følsomme personoplysninger eller personhenførbare informationer.<br/><br/>
+        Læs mere under <a href="https://portal.opendata.dk/dataset/76b7c4cb-2e29-43aa-9b50-eec22b5c3b5e/resource/05e25340-ac7b-460f-a427-41eccb6c36ae/download/open-data-dk-vilkaar-og-betingelser.12.06.18.pdf" target="_blank">Gældende vilkår og betingelser.</a> 
         
       </label>
       


### PR DESCRIPTION
This PR fixes: https://gitlab.com/datopian/core/support/-/issues/207

## Following changes have been made

* The text at the top of the form has been removed
* The link in the checkbox is changed from 
www.portal.opendata.dk with www.opendata.dk
* The redirect link at the bottom of the page is updated to this link: 
https://portal.opendata.dk/dataset/76b7c4cb-2e29-43aa-9b50-eec22b5c3b5e/resource/05e25340-ac7b-460f-a427-41eccb6c36ae/download/open-data-dk-vilkaar-og-betingelser.12.06.18.pdf

## Files changed

* `ckanext/portalopendatadk/templates/package/snippets/resource_form.html`

## New page

* Tested on ckan 2.7
![Screenshot from 2020-04-20 21-28-32](https://user-images.githubusercontent.com/57398621/79775606-eff8c580-834d-11ea-939d-f863cb563670.png)
