### PR TITLE
Adds an updated criteria for setting up passwords when signing up

### DIFF
--- a/ckanext/portalopendatadk/plugin.py
+++ b/ckanext/portalopendatadk/plugin.py
@@ -1,5 +1,13 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
+from ckan.lib.navl.dictization_functions import Missing
+from ckan.logic.schema import default_user_schema, default_update_user_schema
+from ckan.logic.action.create import user_create as core_user_create
+from ckan.logic.action.update import user_update as core_user_update
+
+import string
+_ = toolkit._
+
 
 
 def latest_datasets():
@@ -26,6 +34,7 @@ class PortalOpenDataDKPlugin(plugins.SingletonPlugin):
     '''
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.ITemplateHelpers)
+    plugins.implements(plugins.IActions)
 
     def update_config(self, config):
         toolkit.add_template_directory(config, 'templates')
@@ -35,4 +44,95 @@ class PortalOpenDataDKPlugin(plugins.SingletonPlugin):
     def get_helpers(self):
         return {'portalopendatadk_latest_datasets': latest_datasets,
                 'portalopendatadk_most_popular_datasets': most_popular_datasets}
+    
+    def get_actions(self):
 
+        return {
+            'user_create': custom_user_create,
+            'user_update': custom_user_update,
+        }
+
+# Custom actions
+
+def custom_user_create(context, data_dict):
+
+    context['schema'] = custom_create_user_schema(
+        form_schema='password1' in context.get('schema', {}))
+
+    return core_user_create(context, data_dict)
+
+
+def custom_user_update(context, data_dict):
+
+    context['schema'] = custom_update_user_schema(
+        form_schema='password1' in context.get('schema', {}))
+
+    return core_user_update(context, data_dict)
+
+
+# Custom schemas
+
+def custom_create_user_schema(form_schema=False):
+
+    schema = default_user_schema()
+
+    schema['password'] = [custom_user_password_validator,
+                          toolkit.get_validator('user_password_not_empty'),
+                          toolkit.get_validator('ignore_missing'),
+                          unicode]
+
+    if form_schema:
+        schema['password1'] = [toolkit.get_validator('user_both_passwords_entered'),
+                               custom_user_password_validator,
+                               toolkit.get_validator('user_passwords_match'),
+                               unicode]
+        schema['password2'] = [unicode]
+
+    return schema
+
+
+def custom_update_user_schema(form_schema=False):
+
+    schema = default_update_user_schema()
+
+    schema['password'] = [custom_user_password_validator,
+                          toolkit.get_validator('user_password_not_empty'),
+                          toolkit.get_validator('ignore_missing'),
+                          unicode]
+
+    if form_schema:
+        schema['password'] = [toolkit.get_validator('ignore_missing')]
+        schema['password1'] = [toolkit.get_validator('ignore_missing'),
+                               custom_user_password_validator,
+                               toolkit.get_validator('user_passwords_match'),
+                               unicode]
+        schema['password2'] = [toolkit.get_validator('ignore_missing'),
+                               unicode]
+
+    return schema
+
+
+# Custom validators
+WRONG_PASSWORD_MESSAGE = ('Your password must be 8 characters or longer, ' +
+                          'contain at least one capital letter, one small letter, ' +
+                          'one number(0-9) and a ' +
+                          'special_character(!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~)')
+
+
+def custom_user_password_validator(key, data, errors, context):
+    value = data[key]
+    special_chars = string.punctuation
+
+    if isinstance(value, Missing):
+        pass
+    elif not isinstance(value, basestring):
+        errors[('password',)].append(_('Passwords must be strings'))
+    elif value == '':
+        pass
+    elif (len(value) < 8 or
+          not any(x.isdigit() for x in value) or
+          not any(x.isupper() for x in value) or
+          not any(x.islower() for x in value) or
+          not any(x in special_chars for x in value)
+          ):
+        errors[('password',)].append(_(WRONG_PASSWORD_MESSAGE))

--- a/ckanext/portalopendatadk/plugin.py
+++ b/ckanext/portalopendatadk/plugin.py
@@ -148,8 +148,6 @@ def send_password_notice_email(context, data_dict):
         toolkit.abort(403, _('You are not authorized to access this list'))
 
     user_list = toolkit.get_action('user_list')(context, data_dict)
-    #admin_list = [user for user in user_list if user['sysadmin'] is True]
-
     update_password_email = \
             'Hello {},\n\nWe are improving our user login password security according \
 to the industry standards. Please update your current account password \
@@ -170,13 +168,14 @@ Have a great day.\n\n\
 Message sent by Open Data DK -  (https://admin.opendata.dk)'
 
     for user in user_list:
+        
         email = user['email']
-        if not email:
-            continue
-        mailer.mail_recipient(
-                user['name'], email,
-                'Login security update for Open Data DK portal',
-                update_password_email.format(user['display_name'],
-                config.get('ckan.pass_date','24th June 2020'),
-                config.get('ckan.pass_date','24th June 2020')))
+        
+        if email:
+            mailer.mail_recipient(
+                    user['name'], email,
+                    'Login security update for Open Data DK portal',
+                    update_password_email.format(user['display_name'],
+                    config.get('ckan.pass_date','24th June 2020'),
+                    config.get('ckan.pass_date','24th June 2020')))
     return u'Email Sent Successfully'

--- a/ckanext/portalopendatadk/tests/test_auth.py
+++ b/ckanext/portalopendatadk/tests/test_auth.py
@@ -4,8 +4,6 @@ from routes import url_for
 from ckan.tests import helpers, factories
 from ckan.plugins import toolkit
 
-#from ckanext.portalopendatadk.plugin import WRONG_PASSWORD_MESSAGE
-
 assert_raises = nose.tools.assert_raises
 assert_equal = nose.tools.assert_equal
 
@@ -17,41 +15,6 @@ WRONG_PASSWORD_MESSAGE = ('Your password must be 8 characters or longer, ' +
                           'one number(0-9) and a ' +
                           'special_character(!&#34;#$%&amp;&#39;()*+,-./:;&lt;=&gt;?@[\]^_`{|}~)')
 
-"""class TestUserList(helpers.FunctionalTestBase):
-
-    @classmethod
-    def teardown_class(cls):
-        super(TestUserList, cls).teardown_class()
-        helpers.reset_db()
-
-    def test_not_logged_in(self):
-
-        app = self._get_test_app()
-        app.get(
-            url=url_for(controller='user', action='index'),
-            status=[302],
-        )
-
-    def test_normal_user(self):
-        user = factories.User()
-
-        app = self._get_test_app()
-        env = {'REMOTE_USER': user['name'].encode('ascii')}
-        app.get(
-            url=url_for(controller='user', action='index'),
-            extra_environ=env,
-            status=[401],
-        )
-
-    def test_sysadmin(self):
-        user = factories.Sysadmin()
-
-        app = self._get_test_app()
-        env = {'REMOTE_USER': user['name'].encode('ascii')}
-        app.get(
-            url=url_for(controller='user', action='index'),
-            extra_environ=env,
-        ) """
 class TestPasswordValidator(object):
 
     @classmethod

--- a/ckanext/portalopendatadk/tests/test_auth.py
+++ b/ckanext/portalopendatadk/tests/test_auth.py
@@ -1,0 +1,383 @@
+import nose
+from routes import url_for
+
+from ckan.tests import helpers, factories
+from ckan.plugins import toolkit
+
+#from ckanext.portalopendatadk.plugin import WRONG_PASSWORD_MESSAGE
+
+assert_raises = nose.tools.assert_raises
+assert_equal = nose.tools.assert_equal
+
+submit_and_follow = helpers.submit_and_follow
+webtest_submit = helpers.webtest_submit
+
+WRONG_PASSWORD_MESSAGE = ('Your password must be 8 characters or longer, ' +
+                          'contain at least one capital letter, one small letter, ' +
+                          'one number(0-9) and a ' +
+                          'special_character(!&#34;#$%&amp;&#39;()*+,-./:;&lt;=&gt;?@[\]^_`{|}~)')
+
+"""class TestUserList(helpers.FunctionalTestBase):
+
+    @classmethod
+    def teardown_class(cls):
+        super(TestUserList, cls).teardown_class()
+        helpers.reset_db()
+
+    def test_not_logged_in(self):
+
+        app = self._get_test_app()
+        app.get(
+            url=url_for(controller='user', action='index'),
+            status=[302],
+        )
+
+    def test_normal_user(self):
+        user = factories.User()
+
+        app = self._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        app.get(
+            url=url_for(controller='user', action='index'),
+            extra_environ=env,
+            status=[401],
+        )
+
+    def test_sysadmin(self):
+        user = factories.Sysadmin()
+
+        app = self._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        app.get(
+            url=url_for(controller='user', action='index'),
+            extra_environ=env,
+        ) """
+class TestPasswordValidator(object):
+
+    @classmethod
+    def setup_class(cls):
+        helpers.reset_db()
+
+    @classmethod
+    def teardown_class(cls):
+        helpers.reset_db()
+
+    def test_ok(self):
+
+        factories.User(
+            password='8charsOneUpperCaseandanumber$p3c!@L'
+        )
+
+    def test_length(self):
+
+        assert_raises(toolkit.ValidationError,
+                      factories.User, password='Short7$')
+
+    def test_upper_case(self):
+
+        assert_raises(toolkit.ValidationError,
+                      factories.User, password='loweronly6$')
+
+    def test_number(self):
+
+        assert_raises(toolkit.ValidationError,
+                      factories.User, password='Lettersonly$')
+    def test_special(self):
+
+        assert_raises(toolkit.ValidationError,
+                      factories.User, password='Withoutspecial1')
+
+
+class TestPasswordFunctional(helpers.FunctionalTestBase):
+
+    @classmethod
+    def setup_class(cls):
+        super(cls, cls).setup_class()
+        helpers.reset_db()
+
+    @classmethod
+    def teardown_class(cls):
+        super(cls, cls).teardown_class()
+        helpers.reset_db()
+
+    def test_create_user_ok(self):
+        app = self._get_test_app()
+        env = {}
+
+        response = app.get(
+            url=url_for(controller='user', action='register'),
+        )
+
+        form = response.forms[1]
+        form['name'] = 'new-name'
+        form['fullname'] = 'new full name'
+        form['email'] = 'new@example.com'
+        form['password1'] = '8charsOneUpperCaseandanumber$p3c!@L'
+        form['password2'] = '8charsOneUpperCaseandanumber$p3c!@L'
+
+        response = submit_and_follow(app, form, env, 'save')
+        
+        assert WRONG_PASSWORD_MESSAGE not in response.body
+
+        response = app.get('/user/logout')
+ 
+    def test_create_user_short(self):
+        app = self._get_test_app()
+        env = {}
+
+        response = app.get(
+            url=url_for(controller='user', action='register'),
+        )
+
+        form = response.forms[1]
+        form['name'] = 'new-name'
+        form['fullname'] = 'new full name'
+        form['email'] = 'new@example.com'
+        form['password1'] = 'Short7$'
+        form['password2'] = 'Short7$'
+
+        response = webtest_submit(form, extra_environ=env, name='save')
+
+        assert WRONG_PASSWORD_MESSAGE in response.body
+
+    def test_create_user_lower_only(self):
+        app = self._get_test_app()
+        env = {}
+
+        response = app.get(
+            url=url_for(controller='user', action='register'),
+        )
+
+        form = response.forms[1]
+        form['name'] = 'new-name'
+        form['fullname'] = 'new full name'
+        form['email'] = 'new@example.com'
+        form['password1'] = 'loweronly3@'
+        form['password2'] = 'loweronly3@'
+
+        response = webtest_submit(form, extra_environ=env, name='save')
+
+        assert WRONG_PASSWORD_MESSAGE in response.body
+
+    def test_create_user_letters_only(self):
+        app = self._get_test_app()
+        env = {}
+
+        response = app.get(
+            url=url_for(controller='user', action='register'),
+        )
+
+        form = response.forms[1]
+        form['name'] = 'new-name'
+        form['fullname'] = 'new full name'
+        form['email'] = 'new@example.com'
+        form['password1'] = 'NoNumbers%'
+        form['password2'] = 'NoNumbers%'
+
+        response = webtest_submit(form, extra_environ=env, name='save')
+
+        assert WRONG_PASSWORD_MESSAGE in response.body
+    
+    def test_create_user_without_special(self):
+        app = self._get_test_app()
+        env = {}
+
+        response = app.get(
+            url=url_for(controller='user', action='register'),
+        )
+
+        form = response.forms[1]
+        form['name'] = 'new-name'
+        form['fullname'] = 'new full name'
+        form['email'] = 'new@example.com'
+        form['password1'] = 'NoSpecial'
+        form['password2'] = 'NoSpecial'
+
+        response = webtest_submit(form, extra_environ=env, name='save')
+
+        assert WRONG_PASSWORD_MESSAGE in response.body
+
+    def test_create_user_passwords_dont_match(self):
+        app = self._get_test_app()
+        env = {}
+
+        response = app.get(
+            url=url_for(controller='user', action='register'),
+        )
+
+        form = response.forms[1]
+        form['name'] = 'new-name'
+        form['fullname'] = 'new full name'
+        form['email'] = 'new@example.com'
+        form['password1'] = '8charsOneUpperCaseandanumber$p3c!@L'
+        form['password2'] = '8charsOneUpperCaseandanumber$p3c!AL'
+
+        response = webtest_submit(form, extra_environ=env, name='save')
+
+        assert 'The passwords you entered do not match' in response.body
+
+    def test_create_user_passwords_required(self):
+        app = self._get_test_app()
+        env = {}
+
+        response = app.get(
+            url=url_for(controller='user', action='register'),
+        )
+
+        form = response.forms[1]
+        form['name'] = 'new-name'
+        form['fullname'] = 'new full name'
+        form['email'] = 'new@example.com'
+        form['password1'] = ''
+        form['password2'] = ''
+
+        response = webtest_submit(form, extra_environ=env, name='save')
+
+        assert 'Please enter both passwords' in response.body
+
+    def test_edit_user_ok(self):
+        password = '8charsOneUpperCaseandanumber$p3c!@L'
+        user = factories.User(password=password)
+        app = self._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url=url_for(controller='user', action='edit'),
+            extra_environ=env,
+        )
+
+        form = response.forms['user-edit-form']
+        assert_equal(form['name'].value, user['name'])
+
+        form['old_password'] = password
+        form['password1'] = password + 'new'
+        form['password2'] = password + 'new'
+
+        response = submit_and_follow(app, form, env, 'save')
+
+        assert WRONG_PASSWORD_MESSAGE not in response.body
+
+    def test_edit_user_short(self):
+        password = '8charsOneUpperCaseandanumber$p3c!@L'
+        user = factories.User(password=password)
+        app = self._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url=url_for(controller='user', action='edit'),
+            extra_environ=env,
+        )
+
+        form = response.forms['user-edit-form']
+        assert_equal(form['name'].value, user['name'])
+
+        form['old_password'] = password
+        form['password1'] = 'Short7$'
+        form['password2'] = 'Short7$'
+
+        response = webtest_submit(form, extra_environ=env, name='save')
+
+        assert WRONG_PASSWORD_MESSAGE in response.body
+
+    def test_edit_user_lower_only(self):
+        password = '8charsOneUpperCaseandanumber$p3c!@L'
+        user = factories.User(password=password)
+        app = self._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url=url_for(controller='user', action='edit'),
+            extra_environ=env,
+        )
+
+        form = response.forms['user-edit-form']
+        assert_equal(form['name'].value, user['name'])
+
+        form['old_password'] = password
+        form['password1'] = 'loweronly3@'
+        form['password2'] = 'loweronly3@'
+
+        response = webtest_submit(form, extra_environ=env, name='save')
+
+        assert WRONG_PASSWORD_MESSAGE in response.body
+
+    def test_edit_user_letters_only(self):
+        password = '8charsOneUpperCaseandanumber$p3c!@L'
+        user = factories.User(password=password)
+        app = self._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url=url_for(controller='user', action='edit'),
+            extra_environ=env,
+        )
+
+        form = response.forms['user-edit-form']
+        assert_equal(form['name'].value, user['name'])
+
+        form['old_password'] = password
+        form['password1'] = 'NoNumbers@'
+        form['password2'] = 'NoNumbers@'
+
+        response = webtest_submit(form, extra_environ=env, name='save')
+
+        assert WRONG_PASSWORD_MESSAGE in response.body
+
+    def test_edit_user_without_special(self):
+        password = '8charsOneUpperCaseandanumber$p3c!@L'
+        user = factories.User(password=password)
+        app = self._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url=url_for(controller='user', action='edit'),
+            extra_environ=env,
+        )
+
+        form = response.forms['user-edit-form']
+        assert_equal(form['name'].value, user['name'])
+
+        form['old_password'] = password
+        form['password1'] = 'NoSpecial123'
+        form['password2'] = 'NoSpecial123'
+
+        response = webtest_submit(form, extra_environ=env, name='save')
+
+        assert WRONG_PASSWORD_MESSAGE in response.body
+
+    def test_edit_user_passwords_dont_match(self):
+        password = '8charsOneUpperCaseandanumber$p3c!@L'
+        user = factories.User(password=password)
+        app = self._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url=url_for(controller='user', action='edit'),
+            extra_environ=env,
+        )
+
+        form = response.forms['user-edit-form']
+        assert_equal(form['name'].value, user['name'])
+
+        form['old_password'] = password
+        form['password1'] = '8charsOneUpperCaseandanumber'
+        form['password2'] = '8charsOneUpperCaseandanumber22'
+
+        response = webtest_submit(form, extra_environ=env, name='save')
+
+        assert 'The passwords you entered do not match' in response.body
+
+    def test_edit_user_passwords_required(self):
+        password = '8charsOneUpperCaseandanumber$p3c!@L'
+        user = factories.User(password=password)
+        app = self._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url=url_for(controller='user', action='edit'),
+            extra_environ=env,
+        )
+
+        form = response.forms['user-edit-form']
+        assert_equal(form['name'].value, user['name'])
+
+        form['old_password'] = password
+        form['password1'] = password
+        form['password2'] = ''
+
+        response = webtest_submit(form, extra_environ=env, name='save')
+
+        assert 'The passwords you entered do not match' in response.body

--- a/test.ini
+++ b/test.ini
@@ -1,0 +1,50 @@
+[DEFAULT]
+debug = false
+smtp_server = localhost
+error_email_from = paste@localhost
+
+[server:main]
+use = egg:Paste#http
+host = 0.0.0.0
+port = 5000
+
+[app:main]
+use = config:../../src/ckan/test-core.ini
+
+# Insert any custom config settings to be used when running your extension's
+# tests here.
+ckan.plugins = portalopendatadk
+
+
+# Logging configuration
+[loggers]
+keys = root, ckan, sqlalchemy
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_ckan]
+qualname = ckan
+handlers =
+level = INFO
+
+[logger_sqlalchemy]
+handlers =
+qualname = sqlalchemy.engine
+level = WARN
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s


### PR DESCRIPTION
This PR adds a feature to update the password criteria when signing up for a new user. Tests included.
The core `user_create` and `user_update` functions are not used directly instead are redirected through the new functions `custom_user_create` and `custom_user_update` defined in the `plugin.py` of the extension.

The new criteria for setting up the password
* Password must be of min. 8 chars or longer
* It must have at least
  * One capital letter
  * One small letter
  * One digit
  * One special character

Also adds an endpoint `get_user_email` accessible by sys_admin only to get the display names and email addresses of all the users.
![Screenshot from 2020-08-04 02-07-14](https://user-images.githubusercontent.com/57398621/89227570-5bae2800-d5f7-11ea-98a2-df0b691ee065.png)

Related issue:https://gitlab.com/datopian/core/support/-/issues/231