### PR TITLE
[base.html][xs]: Adds cookie script for admin.opendata.dk

### DIFF
--- a/ckanext/portalopendatadk/templates/base.html
+++ b/ckanext/portalopendatadk/templates/base.html
@@ -8,6 +8,10 @@
      was registered with when the toolkit.add_resource() function was called.
      'style.css' is the path to the CSS file, relative to the root of
      the fanstatic directory. #}
+  <script id="CookieConsent" src="https://policy.app.cookieinformation.com/uc.js"
+
+    data-culture="DA" type="text/javascript"></script>
+
   {% resource 'portalopendatadk/style.css' %}
   {% resource 'portalopendatadk/ga.js' %}
 {% endblock %}


### PR DESCRIPTION
Adds the cookie-popup script in `base.html`

Tested on production site (Wouldnt work locally or on staging)

![Screenshot from 2020-10-05 20-11-45](https://user-images.githubusercontent.com/57398621/95098043-a0fdeb80-0747-11eb-9a0f-1a45929a2d47.png)
