### PR TITLE
Redirect non-admin users to the home page on /user page requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,20 @@ ckanext-portalopendata
 =========
 Theme for portal.opendata.dk
 
-## Custom user viewing permissions
+## Custom user access permissions
 
 This extension has custom code that prevents users other than organization admins and sysadmins from viewing user-related pages and API calls. The following can only be accessed by admins:
 
 - Pages:
   - User list page (`/user`)
-  - User edit pages (`/user/edit/USERNAME`)
+  - User edit pages (`/user/edit/<USERNAME>`)
   - User registration (`/user/register`)
 - API calls:
   - `user_list`
-  - `user_show` (for any user other than themselves)
-
+  - `user_show` (blocked for any user other than themselves)
 
 If a user doesn't have the correct permissions, they will be re-directed to the home page.
+
+**New user registration** is not longer visible for users that aren't logged in, and registration of new users is limited to sysadmins and organization admins. For sysadmins, it can be found both on `/ckan-admin` and `/dashboard`. Organization admins can find it on `/dashboard`.
 
 If any future custom work needs to change this behavior, see the functions in [`auth_functions.py`](ckanext/portalopendatadk/auth_functions.py), `user_has_admin_access` in [`helpers.py`](ckanext/portalopendatadk/helpers.py), the class (`ODDKUserController`) in [`controller.py`](ckanext/portalopendatadk/controller.py), and `before_map` in [`plugin.py`](ckanext/portalopendatadk/plugin.py).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 ckanext-portalopendata
 =========
 Theme for portal.opendata.dk
+
+## Custom user viewing permissions
+
+This extension has custom code that prevents users other than organization admins and sysadmins from viewing user-related pages and API calls. The following can only be accessed by admins:
+
+- Pages:
+  - User list page (`/user`)
+  - User edit pages (`/user/edit/USERNAME`)
+  - User registration (`/user/register`)
+- API calls:
+  - `user_list`
+  - `user_show` (for any user other than themselves)
+
+
+If a user doesn't have the correct permissions, they will be re-directed to the home page.
+
+If any future custom work needs to change this behavior, see the functions in [`auth_functions.py`](ckanext/portalopendatadk/auth_functions.py), `user_has_admin_access` in [`helpers.py`](ckanext/portalopendatadk/helpers.py), the class (`ODDKUserController`) in [`controller.py`](ckanext/portalopendatadk/controller.py), and `before_map` in [`plugin.py`](ckanext/portalopendatadk/plugin.py).

--- a/ckanext/portalopendatadk/auth_functions.py
+++ b/ckanext/portalopendatadk/auth_functions.py
@@ -1,0 +1,104 @@
+# encoding: utf-8
+
+"""
+These auth functions allow only sysadmins to view the API results of `user_list`
+and `user_show`. The origin of these overrides can be found here:
+
+Queensland Government CKAN extension
+https://github.com/qld-gov-au/ckanext-qgov
+"""
+
+from ckan import authz, model
+from ckan.logic import auth as logic_auth
+from ckan.plugins.toolkit import _, asbool, auth_allow_anonymous_access
+
+from ckanext.portalopendatadk.helpers import user_has_admin_access
+
+
+
+def user_list(context, data_dict=None):
+    """Check whether access to the user list is authorised.
+    Restricted to organisation admins as per QOL-5710.
+    """
+    return {'success': _requester_is_admin(context)}
+
+
+@auth_allow_anonymous_access
+def user_show(context, data_dict):
+    """Check whether access to individual user details is authorised.
+    Restricted to organisation admins or self, as per QOL-5710.
+    """
+    if _requester_is_admin(context):
+        return {'success': True}
+    requester = context.get('user')
+    id = data_dict.get('id', None)
+    if id:
+        user_obj = model.User.get(id)
+    else:
+        user_obj = data_dict.get('user_obj', None)
+    if user_obj:
+        return {'success': requester in [user_obj.name, user_obj.id]}
+
+    return {'success': False}
+
+
+@auth_allow_anonymous_access
+def group_show(context, data_dict):
+    """Check whether access to a group is authorised.
+    If it's just the group metadata, this requires no privileges,
+    but if user details have been requested, it requires a group admin.
+    """
+    user = context.get('user')
+    group = logic_auth.get_group_object(context, data_dict)
+    if group.state == 'active' and \
+        not asbool(data_dict.get('include_users', False)) and \
+            data_dict.get('object_type', None) != 'user':
+        return {'success': True}
+    authorized = authz.has_user_permission_for_group_or_org(
+        group.id, user, 'update')
+    if authorized:
+        return {'success': True}
+    else:
+        return {'success': False,
+                'msg': _('User %s not authorized to read group %s') % (user, group.id)}
+
+
+def _requester_is_admin(context):
+    """Check whether the current user has admin privileges in some group
+    or organisation.
+    This is based on the 'update' privilege; see eg
+    ckan.logic.auth.update.group_edit_permissions.
+    """
+    requester = context.get('user')
+    return _has_user_permission_for_some_group(requester, 'admin')
+
+
+def _has_user_permission_for_some_group(user_name, permission):
+    """Check if the user has the given permission for any group.
+    """
+    user_id = authz.get_user_id_for_username(user_name, allow_none=True)
+    if not user_id:
+        return False
+    roles = authz.get_roles_with_permission(permission)
+
+    if not roles:
+        return False
+    # get any groups the user has with the needed role
+    q = model.Session.query(model.Member) \
+        .filter(model.Member.table_name == 'user') \
+        .filter(model.Member.state == 'active') \
+        .filter(model.Member.capacity.in_(roles)) \
+        .filter(model.Member.table_id == user_id)
+    group_ids = []
+    for row in q.all():
+        group_ids.append(row.group_id)
+    # if not in any groups has no permissions
+    if not group_ids:
+        return False
+
+    # see if any of the groups are active
+    q = model.Session.query(model.Group) \
+        .filter(model.Group.state == 'active') \
+        .filter(model.Group.id.in_(group_ids))
+
+    return bool(q.count())

--- a/ckanext/portalopendatadk/auth_functions.py
+++ b/ckanext/portalopendatadk/auth_functions.py
@@ -1,8 +1,8 @@
 # encoding: utf-8
 
 """
-These auth functions allow only sysadmins to view the API results of `user_list`
-and `user_show`. The origin of these overrides can be found here:
+These auth functions allow only sysadmins to view the API results of `user_list` and `user_show`.
+The origin of these overrides (and imported helper: `user_has_admin_access`) can be found here:
 
 Queensland Government CKAN extension
 https://github.com/qld-gov-au/ckanext-qgov
@@ -12,13 +12,10 @@ from ckan import authz, model
 from ckan.logic import auth as logic_auth
 from ckan.plugins.toolkit import _, asbool, auth_allow_anonymous_access
 
-from ckanext.portalopendatadk.helpers import user_has_admin_access
-
-
 
 def user_list(context, data_dict=None):
     """Check whether access to the user list is authorised.
-    Restricted to organisation admins as per QOL-5710.
+    Restricted to organisation admins or sysadmins.
     """
     return {'success': _requester_is_admin(context)}
 
@@ -26,7 +23,7 @@ def user_list(context, data_dict=None):
 @auth_allow_anonymous_access
 def user_show(context, data_dict):
     """Check whether access to individual user details is authorised.
-    Restricted to organisation admins or self, as per QOL-5710.
+    Restricted to organisation admins, sysadmin, or self.
     """
     if _requester_is_admin(context):
         return {'success': True}
@@ -46,7 +43,7 @@ def user_show(context, data_dict):
 def group_show(context, data_dict):
     """Check whether access to a group is authorised.
     If it's just the group metadata, this requires no privileges,
-    but if user details have been requested, it requires a group admin.
+    but if user details have been requested, it requires a group admin or sysadmin.
     """
     user = context.get('user')
     group = logic_auth.get_group_object(context, data_dict)

--- a/ckanext/portalopendatadk/controller.py
+++ b/ckanext/portalopendatadk/controller.py
@@ -74,7 +74,9 @@ class ODDKUserController(UserController):
             data_dict = logic.clean_dict(unflatten(
                 logic.tuplize_dict(logic.parse_params(request.params))))
             context['message'] = data_dict.get('log_message', '')
-            captcha.check_recaptcha(request)
+            # NOTE: On ODDK, we don't need a captcha as there's
+            # no public registration.
+            # captcha.check_recaptcha(request)
             user = get_action('user_create')(context, data_dict)
         except NotAuthorized:
             abort(403, _('Unauthorized to create user %s') % '')
@@ -82,10 +84,15 @@ class ODDKUserController(UserController):
             abort(404, _('User not found'))
         except DataError:
             abort(400, _(u'Integrity Error'))
-        except captcha.CaptchaError:
-            error_msg = _(u'Bad Captcha. Please try again.')
-            h.flash_error(error_msg)
-            return self.new(data_dict)
+
+        # NOTE: On ODDK, we don't need a captcha as there's
+        # no public registration.
+        #
+        # except captcha.CaptchaError:
+        #     error_msg = _(u'Bad Captcha. Please try again.')
+        #     h.flash_error(error_msg)
+        #     return self.new(data_dict)
+
         except ValidationError, e:
             errors = e.error_dict
             error_summary = e.error_summary

--- a/ckanext/portalopendatadk/controller.py
+++ b/ckanext/portalopendatadk/controller.py
@@ -1,55 +1,17 @@
-from ckan.lib.navl.validators import not_empty
-
 from ckan.controllers.user import UserController
 import logging as log
 from ckan import authz
-import ckan.plugins.toolkit as toolkit
 from ckan.common import c
-from ckan import model
+import ckan.lib.helpers as h
 
 
 
-class CustomUserController(UserController):
-    """This controller is an example to show how you might extend or
-    override core CKAN behaviour from an extension package.
-    It overrides 2 method hooks which the base class uses to create the
-    validation schema for the creation and editing of a user; to require
-    that a fullname is given.
-    """
-    context = {'model': model, 'session': model.Session,
-               'user': c.user, 'auth_user_obj': c.userobj}
+class ODDKUserController(UserController):
+    def __before__(self, action, **env):
+        UserController.__before__(self, action, **env)
 
-    log.error('111111111111111111111111111111111111')
-    log.error(context['auth_user_obj'])
-    log.error(c.user)
-    if not authz.is_sysadmin(toolkit.c.user):
-        log.error('547894574895734897589345738945734')
+        log.error(authz.is_sysadmin(c.user))
 
-    #new_user_form = 'user/register.html'
-
-    #def _add_requires_full_name_to_schema(self, schema):
-    #    """
-    #    Helper function that modifies the fullname validation on an existing schema
-    #    """
-    #    schema['fullname'] = [not_empty, unicode]
-
-    #def _new_form_to_db_schema(self):
-    #    """
-    #    Defines a custom schema that requires a full name to be supplied
-    #    This method is a hook that the base class calls for the validation
-    #    schema to use when creating a new user.
-    #    """
-    #    schema = super(CustomUserController, self)._new_form_to_db_schema()
-    #    self._add_requires_full_name_to_schema(schema)
-    #    return schema
-
-    #def _edit_form_to_db_schema(self):
-    #    """
-    #    Defines a custom schema that requires a full name cannot be removed
-    #    when editing the user.
-    #    This method is a hook that the base class calls for the validation
-    #    schema to use when editing an exiting user.
-    #    """
-    #    schema = super(CustomUserController, self)._edit_form_to_db_schema()
-    #    self._add_requires_full_name_to_schema(schema)
-    #    return schema
+        # Verify user is a sysadmin, else redirect to the home page
+        if not authz.is_sysadmin(c.user):
+            h.redirect_to(controller='home', action='index')

--- a/ckanext/portalopendatadk/controller.py
+++ b/ckanext/portalopendatadk/controller.py
@@ -1,10 +1,29 @@
-from ckan.controllers.user import UserController
 import logging as log
+
+from ckan.controllers.user import UserController, set_repoze_user
 from ckan import authz
 from ckan.common import c
 import ckan.lib.helpers as h
+import ckan.lib.base as base
+import ckan.model as model
+import ckan.logic as logic
+from ckan.common import _, c, request
+import ckan.lib.navl.dictization_functions as dictization_functions
+import ckan.lib.captcha as captcha
+
 from ckanext.portalopendatadk.helpers import user_has_admin_access
 
+abort = base.abort
+render = base.render
+
+check_access = logic.check_access
+get_action = logic.get_action
+NotAuthorized = logic.NotAuthorized
+NotFound = logic.NotFound
+ValidationError = logic.ValidationError
+
+DataError = dictization_functions.DataError
+unflatten = dictization_functions.unflatten
 
 
 class ODDKUserController(UserController):
@@ -14,3 +33,89 @@ class ODDKUserController(UserController):
         # Verify user is an admin, else redirect to the home page
         if not user_has_admin_access(False):
             h.redirect_to(controller='home', action='index')
+
+    def new(self, data=None, errors=None, error_summary=None):
+        '''GET to display a form for registering a new user.
+           or POST the form data to actually do the user registration.
+        '''
+        context = {'model': model,
+                   'session': model.Session,
+                   'user': c.user,
+                   'auth_user_obj': c.userobj,
+                   'schema': self._new_form_to_db_schema(),
+                   'save': 'save' in request.params}
+
+        try:
+            check_access('user_create', context)
+        except NotAuthorized:
+            abort(403, _('Unauthorized to create a user'))
+
+        if context['save'] and not data and request.method == 'POST':
+            return self._save_new(context)
+
+        # NOTE: On ODDK, we need to check if the user is a sysadmin _or_ an
+        # organization admin. We should never pass this check, but I'll
+        # leave it here for now, just in case.
+        if c.user and not data and not user_has_admin_access(False):
+            # #1799 Don't offer the registration form if already logged in
+            return render('user/logout_first.html')
+
+        data = data or {}
+        errors = errors or {}
+        error_summary = error_summary or {}
+        vars = {'data': data, 'errors': errors, 'error_summary': error_summary}
+
+        c.is_sysadmin = authz.is_sysadmin(c.user)
+        c.form = render(self.new_user_form, extra_vars=vars)
+        return render('user/new.html')
+
+    def _save_new(self, context):
+        try:
+            data_dict = logic.clean_dict(unflatten(
+                logic.tuplize_dict(logic.parse_params(request.params))))
+            context['message'] = data_dict.get('log_message', '')
+            captcha.check_recaptcha(request)
+            user = get_action('user_create')(context, data_dict)
+        except NotAuthorized:
+            abort(403, _('Unauthorized to create user %s') % '')
+        except NotFound, e:
+            abort(404, _('User not found'))
+        except DataError:
+            abort(400, _(u'Integrity Error'))
+        except captcha.CaptchaError:
+            error_msg = _(u'Bad Captcha. Please try again.')
+            h.flash_error(error_msg)
+            return self.new(data_dict)
+        except ValidationError, e:
+            errors = e.error_dict
+            error_summary = e.error_summary
+            return self.new(data_dict, errors, error_summary)
+        if not c.user:
+            # log the user in programatically
+            set_repoze_user(data_dict['name'])
+            h.redirect_to(controller='user', action='me')
+        else:
+            # NOTE: On ODDK, we bypass this. Only sysadmins and organization admins
+            # can register new users.
+            #
+            # #1799 User has managed to register whilst logged in - warn user
+            # they are not re-logged in as new user.
+            #
+            # h.flash_success(_('User "%s" is now registered but you are still '
+            #                 'logged in as "%s" from before') %
+            #                 (data_dict['name'], c.user))
+
+            # NOTE: On ODDK, we should always redirect to the activity page
+            # for the newly created user.
+            #
+            #if authz.is_sysadmin(c.user):
+            #    # the sysadmin created a new user. We redirect him to the
+            #    # activity page for the newly created user
+            #    h.redirect_to(controller='user',
+            #                  action='activity',
+            #                  id=data_dict['name'])
+            #else:
+            #    return render('user/logout_first.html')
+
+            h.flash_success(_('User "%s" is now registered.' % data_dict['name']))
+            h.redirect_to(controller='user', action='activity', id=data_dict['name'])

--- a/ckanext/portalopendatadk/controller.py
+++ b/ckanext/portalopendatadk/controller.py
@@ -1,0 +1,55 @@
+from ckan.lib.navl.validators import not_empty
+
+from ckan.controllers.user import UserController
+import logging as log
+from ckan import authz
+import ckan.plugins.toolkit as toolkit
+from ckan.common import c
+from ckan import model
+
+
+
+class CustomUserController(UserController):
+    """This controller is an example to show how you might extend or
+    override core CKAN behaviour from an extension package.
+    It overrides 2 method hooks which the base class uses to create the
+    validation schema for the creation and editing of a user; to require
+    that a fullname is given.
+    """
+    context = {'model': model, 'session': model.Session,
+               'user': c.user, 'auth_user_obj': c.userobj}
+
+    log.error('111111111111111111111111111111111111')
+    log.error(context['auth_user_obj'])
+    log.error(c.user)
+    if not authz.is_sysadmin(toolkit.c.user):
+        log.error('547894574895734897589345738945734')
+
+    #new_user_form = 'user/register.html'
+
+    #def _add_requires_full_name_to_schema(self, schema):
+    #    """
+    #    Helper function that modifies the fullname validation on an existing schema
+    #    """
+    #    schema['fullname'] = [not_empty, unicode]
+
+    #def _new_form_to_db_schema(self):
+    #    """
+    #    Defines a custom schema that requires a full name to be supplied
+    #    This method is a hook that the base class calls for the validation
+    #    schema to use when creating a new user.
+    #    """
+    #    schema = super(CustomUserController, self)._new_form_to_db_schema()
+    #    self._add_requires_full_name_to_schema(schema)
+    #    return schema
+
+    #def _edit_form_to_db_schema(self):
+    #    """
+    #    Defines a custom schema that requires a full name cannot be removed
+    #    when editing the user.
+    #    This method is a hook that the base class calls for the validation
+    #    schema to use when editing an exiting user.
+    #    """
+    #    schema = super(CustomUserController, self)._edit_form_to_db_schema()
+    #    self._add_requires_full_name_to_schema(schema)
+    #    return schema

--- a/ckanext/portalopendatadk/controller.py
+++ b/ckanext/portalopendatadk/controller.py
@@ -3,6 +3,7 @@ import logging as log
 from ckan import authz
 from ckan.common import c
 import ckan.lib.helpers as h
+from ckanext.portalopendatadk.helpers import user_has_admin_access
 
 
 
@@ -10,8 +11,6 @@ class ODDKUserController(UserController):
     def __before__(self, action, **env):
         UserController.__before__(self, action, **env)
 
-        log.error(authz.is_sysadmin(c.user))
-
-        # Verify user is a sysadmin, else redirect to the home page
-        if not authz.is_sysadmin(c.user):
+        # Verify user is an admin, else redirect to the home page
+        if not user_has_admin_access(False):
             h.redirect_to(controller='home', action='index')

--- a/ckanext/portalopendatadk/fanstatic/style.css
+++ b/ckanext/portalopendatadk/fanstatic/style.css
@@ -103,3 +103,7 @@ body {
         color: #444444;
         font-size: x-large;
 }
+
+#add-user-button {
+        float: right;
+}

--- a/ckanext/portalopendatadk/helpers.py
+++ b/ckanext/portalopendatadk/helpers.py
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+from ckan.plugins import toolkit
+
+
+def user_has_admin_access(include_editor_access):
+    user = toolkit.c.userobj
+    # If user is "None" - they are not logged in.
+    if user is None:
+        return False
+    if user.sysadmin:
+        return True
+
+    groups_admin = user.get_groups('organization', 'admin')
+    groups_editor = user.get_groups('organization', 'editor') if include_editor_access else []
+    groups_list = groups_admin + groups_editor
+    organisation_list = [g for g in groups_list if g.type == 'organization']
+    return len(organisation_list) > 0

--- a/ckanext/portalopendatadk/plugin.py
+++ b/ckanext/portalopendatadk/plugin.py
@@ -12,6 +12,7 @@ from ckan import authz
 
 from ckanext.portalopendatadk import actions as oddk_actions
 from ckanext.portalopendatadk import auth_functions as auth
+from ckanext.portalopendatadk.helpers import user_has_admin_access
 
 _ = toolkit._
 
@@ -86,7 +87,8 @@ class PortalOpenDataDKPlugin(plugins.SingletonPlugin, DefaultTranslation, toolki
     def get_helpers(self):
         return {'portalopendatadk_latest_datasets': latest_datasets,
                 'portalopendatadk_most_popular_datasets': most_popular_datasets,
-                'get_update_frequencies': get_update_frequencies}
+                'get_update_frequencies': get_update_frequencies,
+                'user_has_admin_access': user_has_admin_access}
 
     def get_actions(self):
 

--- a/ckanext/portalopendatadk/plugin.py
+++ b/ckanext/portalopendatadk/plugin.py
@@ -11,6 +11,7 @@ from pylons import config
 from ckan import authz
 
 from ckanext.portalopendatadk import actions as oddk_actions
+from ckanext.portalopendatadk import auth_functions as auth
 
 _ = toolkit._
 
@@ -45,6 +46,7 @@ class PortalOpenDataDKPlugin(plugins.SingletonPlugin, DefaultTranslation, toolki
     plugins.implements(plugins.IDatasetForm, inherit=True)
     plugins.implements(plugins.IFacets)
     plugins.implements(plugins.IRoutes, inherit=True)
+    plugins.implements(plugins.IAuthFunctions, inherit=True)
 
     def before_map(self, map):
         # Pass requests to ODDKUserController to verify admin status
@@ -112,6 +114,19 @@ class PortalOpenDataDKPlugin(plugins.SingletonPlugin, DefaultTranslation, toolki
     def group_facets(self, facets_dict, group_type, package_type):
         facets_dict['update_frequency'] = plugins.toolkit._('Update frequency')
         return facets_dict
+
+    # IAuthFunctions
+
+    def get_auth_functions(self):
+        """ Override the 'related' auth functions with our own.
+        """
+        auth_functions = {
+            'user_list': auth.user_list,
+            'user_show': auth.user_show,
+            'group_show': auth.group_show
+        }
+
+        return auth_functions
 
 # Custom actions
 

--- a/ckanext/portalopendatadk/plugin.py
+++ b/ckanext/portalopendatadk/plugin.py
@@ -44,6 +44,37 @@ class PortalOpenDataDKPlugin(plugins.SingletonPlugin, DefaultTranslation, toolki
     plugins.implements(plugins.ITranslation)
     plugins.implements(plugins.IDatasetForm, inherit=True)
     plugins.implements(plugins.IFacets)
+    plugins.implements(plugins.IRoutes, inherit=True)
+
+    def before_map(self, map):
+        # Pass requests to ODDKUserController to verify admin status
+        map.connect(
+            '/user',
+            controller='ckanext.portalopendatadk.controller:ODDKUserController',
+            action='index'
+        )
+        map.connect(
+            '/user/register',
+            controller='ckanext.portalopendatadk.controller:ODDKUserController',
+            action='register'
+        )
+        map.connect(
+            '/user/edit',
+            controller='ckanext.portalopendatadk.controller:ODDKUserController',
+            action='edit'
+        )
+        map.connect(
+            '/user/edit/{id:.*}',
+            controller='ckanext.portalopendatadk.controller:ODDKUserController',
+            action='edit'
+        )
+
+        return map
+
+
+    def after_map(self, map):
+        return map
+
 
     def update_config(self, config):
         toolkit.add_template_directory(config, 'templates')

--- a/ckanext/portalopendatadk/templates/admin/base.html
+++ b/ckanext/portalopendatadk/templates/admin/base.html
@@ -20,6 +20,6 @@
       {{ h.build_extra_admin_nav() }}
     {% endblock %}
   </ul>
-  <a class="btn" id="add-user-button" href="{{ h.url_for(controller='user', action='register') }}">{{ _('Create an Account') }}</a>
+  <div id="add-user-button">{% link_for _('Create an Account'), controller='user', action='register', class_='btn', icon='plus' %}</div>
 </header>
 {% endblock %}

--- a/ckanext/portalopendatadk/templates/admin/base.html
+++ b/ckanext/portalopendatadk/templates/admin/base.html
@@ -1,0 +1,25 @@
+{% extends "page.html" %}
+
+{% block subtitle %}{{ _('Administration') }}{% endblock %}
+
+{% block breadcrumb_content %}{% endblock %}
+
+
+{% block page_header %}
+<header class="module-content page-header">
+  {% if self.content_action() | trim %}
+    <div class="content_action">
+      {% block content_action %}{% endblock %}
+    </div>
+  {% endif %}
+  <ul class="nav nav-tabs">
+    {% block content_primary_nav %}
+      {{ h.build_nav_icon('ckanadmin_index', _('Sysadmins')) }}
+      {{ h.build_nav_icon('ckanadmin_config', _('Config')) }}
+      {{ h.build_nav_icon('ckanadmin_trash', _('Trash')) }}
+      {{ h.build_extra_admin_nav() }}
+    {% endblock %}
+  </ul>
+  <a class="btn" id="add-user-button" href="{{ h.url_for(controller='user', action='register') }}">{{ _('Create an Account') }}</a>
+</header>
+{% endblock %}

--- a/ckanext/portalopendatadk/templates/header.html
+++ b/ckanext/portalopendatadk/templates/header.html
@@ -55,9 +55,6 @@
             <ul class="unstyled">
               {% block header_account_notlogged %}
               <li>{% link_for _('Log in'), controller='user', action='login' %}</li>
-              {% if h.check_access('user_create') %}
-                <li>{% link_for _('Register'), controller='user', action='register', class_='sub' %}</li>
-              {% endif %}
               {% endblock %}
             </ul>
           </nav>

--- a/ckanext/portalopendatadk/templates/user/dashboard.html
+++ b/ckanext/portalopendatadk/templates/user/dashboard.html
@@ -1,0 +1,53 @@
+{% extends "user/edit_base.html" %}
+
+{% set user = c.userobj %}
+
+{% block breadcrumb_content %}
+  <li class="active"><a href="{{ h.url_for(controller='user', action='dashboard') }}">{{ _('Dashboard') }}</a></li>
+{% endblock %}
+
+{% block secondary %}{% endblock %}
+
+{% block primary %}
+  <article class="module">
+    {% block page_header %}
+      <header class="module-content page-header hug">
+        <div class="content_action">
+          {% if h.user_has_admin_access(False) %}
+            {% link_for _('Create an Account'), controller='user', action='register', class_='btn', icon='plus' %}
+          {% endif %}
+          {% link_for _('Edit settings'), controller='user', action='edit', id=user.name, class_='btn', icon='cog' %}
+        </div>
+    {% block content_primary_nav %}
+        <ul class="nav nav-tabs">
+          {{ h.build_nav_icon('user_dashboard', _('News feed')) }}
+          {{ h.build_nav_icon('user_dashboard_datasets', _('My Datasets')) }}
+          {{ h.build_nav_icon('user_dashboard_organizations', _('My Organizations')) }}
+          {{ h.build_nav_icon('user_dashboard_groups', _('My Groups')) }}
+        </ul>
+     {% endblock %}
+      </header>
+    {% endblock %}
+    <div class="module-content">
+      {% if self.page_primary_action() | trim %}
+        <div class="page_primary_action">
+          {% block page_primary_action %}{% endblock %}
+        </div>
+      {% endif %}
+      {% block primary_content_inner %}
+        <div data-module="dashboard">
+          {% snippet 'user/snippets/followee_dropdown.html', context=c.dashboard_activity_stream_context, followees=c.followee_list %}
+          <h2 class="page-heading">
+            {% block page_heading %}
+              {{ _('News feed') }}
+            {% endblock %}
+            <small>{{ _("Activity from items that I'm following") }}</small>
+          </h2>
+          {% block activity_stream %}
+            {{ c.dashboard_activity_stream }}
+          {% endblock %}
+        </div>
+      {% endblock %}
+    </div>
+  </article>
+{% endblock %}

--- a/ckanext/portalopendatadk/templates/user/login.html
+++ b/ckanext/portalopendatadk/templates/user/login.html
@@ -1,0 +1,36 @@
+{% extends "page.html" %}
+
+{% block subtitle %}{{ _('Login') }}{% endblock %}
+
+{% block breadcrumb_content %}
+  <li class="active">{{ h.nav_link(_('Login'), controller='user', action='login') }}</li>
+{% endblock %}
+
+{% block primary_content %}
+  <section class="module">
+    <div class="module-content">
+      <h1 class="page-heading">{% block page_heading %}{{ _('Login') }}{% endblock %}</h1>
+      {% block form %}
+        {% snippet "user/snippets/login_form.html", action=c.login_handler, error_summary=error_summary %}
+      {% endblock %}
+    </div>
+  </section>
+{% endblock %}
+
+{% block secondary_content %}
+  {% block help_forgotten %}
+  <section class="module module-narrow module-shallow">
+    {% block help_forgotten_inner %}
+    <h2 class="module-heading">{{ _('Forgotten your password?') }}</h2>
+    <div class="module-content">
+      <p>{% trans %}No problem, use our password recovery form to reset it.{% endtrans %}</p>
+      <p class="action">
+        {% block help_forgotten_button %}
+        <a class="btn" href="{{ h.url_for(controller='user', action='request_reset') }}">{{ _('Forgot your password?') }}</a>
+        {% endblock %}
+      </p>
+    </div>
+    {% endblock %}
+  </section>
+  {% endblock %}
+{% endblock %}


### PR DESCRIPTION
You can see the changes to test in the [updated README](https://github.com/datopian/ckanext-portalopendatadk/tree/user-page-admin-access#custom-user-access-permissions).

And here are screenshots of the button placements/locations (see the button "Opret en konto" on `/dashboard` if you're an organization admin or on `/dashboard` and `/ckan-admin` if you're a sysadmin):

![Screenshot - 2022-09-13T150000 769](https://user-images.githubusercontent.com/19521691/189992983-f299c267-e193-46d3-a816-6403fd1ef1ae.png)

![Screenshot - 2022-09-13T150016 073](https://user-images.githubusercontent.com/19521691/189993211-a0a8ce12-fa2c-40bc-a8f2-5098c72723e3.png)

