### PR TITLE
[org_admin][s]: restricted org admins to create new user

### DIFF
--- a/ckanext/portalopendatadk/controller.py
+++ b/ckanext/portalopendatadk/controller.py
@@ -35,6 +35,8 @@ class ODDKUserController(UserController):
         # else redirect to the home page
         if not user_has_admin_access(False) and action != 'request_reset':
             h.redirect_to(controller='home', action='index')
+        if not authz.is_sysadmin(c.user) and action == 'register':
+            h.redirect_to(controller='home', action='index')
 
     def new(self, data=None, errors=None, error_summary=None):
         '''GET to display a form for registering a new user.

--- a/ckanext/portalopendatadk/templates/organization/member_new.html
+++ b/ckanext/portalopendatadk/templates/organization/member_new.html
@@ -2,76 +2,61 @@
 
 {% import 'macros/form.html' as form %}
 
-{% set user = user_dict %}
+{% set user = c.user_dict %}
 
-{% block subtitle %}{{ _('Edit Member') if user else _('Add Member') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('Edit Member') if user else _('Add Member') }} - {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  {% link_for _('Back to all members'), named_route=group_type+'.members', id=organization.name, class_='btn btn-default pull-right', icon='arrow-left' %}
+  {% link_for _('Back to all members'), controller='organization', action='members', id=organization.name, class_='btn pull-right', icon='arrow-left' %}
   <h1 class="page-heading">
     {% block page_heading %}{{ _('Edit Member') if user else _('Add Member') }}{% endblock %}
   </h1>
   {% block form %}
-  <form class="dataset-form add-member-form" method='post'>
-    {{ h.csrf_input() }}
-    <div class="row">
-      <div class="col-md-5">
-        <div class="form-group control-medium">
-          {% if not user %}
-            <label class="form-label" for="username">
-              {{ _('Existing User') }}
-            </label>
-            <p>
-              {{ _('If you wish to add an existing user, search for their username below.') }}
-            </p>
+  <form class="dataset-form form-horizontal add-member-form" method='post'>
+    <div class="row-fluid">
+      <div class="control-group control-medium">
+        {% if not user %}
+          <label class="control-label" for="username">
+            {{ _('Existing User') }}
+          </label>
+          <span>
+            {{ _('If you wish to add an existing user, search for their username below.') }}
+          </span>
+        {% endif %}
+        <div class="controls">
+          {% if user %}
+            <input type="hidden" name="username" value="{{ user.name }}" />
+            <input id="username" name="username" type="text" value="{{ user.name }}"
+            disabled="True" class="control-medium">
+          {% else %}
+             <input id="username" type="text" name="username" placeholder="{{ _('Username') }}"
+            value="" class="control-medium" data-module="autocomplete"
+            data-module-source="/api/2/util/user/autocomplete?q=?">
           {% endif %}
-          <div class="controls">
-            {% if user %}
-              <input type="hidden" name="username" value="{{ user.name }}" />
-              <input id="username" name="username" type="text" value="{{ user.name }}"
-              disabled="True" class="form-control">
-            {% else %}
-                <input id="username" type="text" name="username" placeholder="{{ _('Username') }}"
-                value="" class="control-medium" data-module="autocomplete"
-                data-module-source="/api/2/util/user/autocomplete?ignore_self=true&q=?">
-            {% endif %}
-          </div>
         </div>
       </div>
       {% if c.userobj.sysadmin %}
-      <div class="col-md-2 add-member-or-wrap">
         <div class="add-member-or">
           {{ _('or') }}
         </div>
-      </div>
-      <div class="col-md-5">
-        <div class="form-group control-medium">
-          <label class="form-label" for="email">
+        <div class="control-group control-medium">
+          <label class="control-label" for="email">
             {{ _('New User') }}
           </label>
-          <p>
+          <span>
             {{ _('If you wish to invite a new user, enter their email address.') }}
-          </p>
+          </span>
           <div class="controls">
-            <input id="email" type="email" name="email" class="form-control" placeholder="{{ _('Email address') }}" >
+            <input id="email" type="email" name="email" placeholder="{{ _('Email address') }}" >
           </div>
         </div>
-      </div>
       {% endif %}
     </div>
-
-    {% if user and user.name == c.user and user_role == 'admin' %}
-      {% set format_attrs = {'data-module': 'autocomplete', 'disabled': 'disabled'} %}
-      {{ form.select('role', label=_('Role'), options=roles, selected=user_role, error='', attrs=format_attrs) }}
-      {{ form.hidden('role', value=user_role) }}
-    {% else %}
-      {% set format_attrs = {'data-module': 'autocomplete'} %}
-      {{ form.select('role', label=_('Role'), options=roles, selected=user_role, error='', attrs=format_attrs) }}
-    {% endif %}
-
+    {% set format_attrs = {'data-module': 'autocomplete'} %}
+    {{ form.select('role', label=_('Role'), options=c.roles, selected=c.user_role, error='', attrs=format_attrs) }}
     <div class="form-actions">
       {% if user %}
-        <a href="{{ h.url_for(group_type + '.member_delete', id=group_dict.id, user=user.id) }}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}">{{ _('Delete') }}</a>
+        <a href="{% url_for controller='organization', action='member_delete', id=c.group_dict.id, user=user.id %}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}">{{ _('Delete') }}</a>
         <button class="btn btn-primary" type="submit" name="submit" >
           {{ _('Update Member') }}
         </button>
@@ -102,5 +87,4 @@
         datasets, but not add new datasets.</p>
     {% endtrans %}
   </div>
-</div>
 {% endblock %}

--- a/ckanext/portalopendatadk/templates/organization/member_new.html
+++ b/ckanext/portalopendatadk/templates/organization/member_new.html
@@ -1,0 +1,106 @@
+{% extends "organization/edit_base.html" %}
+
+{% import 'macros/form.html' as form %}
+
+{% set user = user_dict %}
+
+{% block subtitle %}{{ _('Edit Member') if user else _('Add Member') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
+
+{% block primary_content_inner %}
+  {% link_for _('Back to all members'), named_route=group_type+'.members', id=organization.name, class_='btn btn-default pull-right', icon='arrow-left' %}
+  <h1 class="page-heading">
+    {% block page_heading %}{{ _('Edit Member') if user else _('Add Member') }}{% endblock %}
+  </h1>
+  {% block form %}
+  <form class="dataset-form add-member-form" method='post'>
+    {{ h.csrf_input() }}
+    <div class="row">
+      <div class="col-md-5">
+        <div class="form-group control-medium">
+          {% if not user %}
+            <label class="form-label" for="username">
+              {{ _('Existing User') }}
+            </label>
+            <p>
+              {{ _('If you wish to add an existing user, search for their username below.') }}
+            </p>
+          {% endif %}
+          <div class="controls">
+            {% if user %}
+              <input type="hidden" name="username" value="{{ user.name }}" />
+              <input id="username" name="username" type="text" value="{{ user.name }}"
+              disabled="True" class="form-control">
+            {% else %}
+                <input id="username" type="text" name="username" placeholder="{{ _('Username') }}"
+                value="" class="control-medium" data-module="autocomplete"
+                data-module-source="/api/2/util/user/autocomplete?ignore_self=true&q=?">
+            {% endif %}
+          </div>
+        </div>
+      </div>
+      {% if c.userobj.sysadmin %}
+      <div class="col-md-2 add-member-or-wrap">
+        <div class="add-member-or">
+          {{ _('or') }}
+        </div>
+      </div>
+      <div class="col-md-5">
+        <div class="form-group control-medium">
+          <label class="form-label" for="email">
+            {{ _('New User') }}
+          </label>
+          <p>
+            {{ _('If you wish to invite a new user, enter their email address.') }}
+          </p>
+          <div class="controls">
+            <input id="email" type="email" name="email" class="form-control" placeholder="{{ _('Email address') }}" >
+          </div>
+        </div>
+      </div>
+      {% endif %}
+    </div>
+
+    {% if user and user.name == c.user and user_role == 'admin' %}
+      {% set format_attrs = {'data-module': 'autocomplete', 'disabled': 'disabled'} %}
+      {{ form.select('role', label=_('Role'), options=roles, selected=user_role, error='', attrs=format_attrs) }}
+      {{ form.hidden('role', value=user_role) }}
+    {% else %}
+      {% set format_attrs = {'data-module': 'autocomplete'} %}
+      {{ form.select('role', label=_('Role'), options=roles, selected=user_role, error='', attrs=format_attrs) }}
+    {% endif %}
+
+    <div class="form-actions">
+      {% if user %}
+        <a href="{{ h.url_for(group_type + '.member_delete', id=group_dict.id, user=user.id) }}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}">{{ _('Delete') }}</a>
+        <button class="btn btn-primary" type="submit" name="submit" >
+          {{ _('Update Member') }}
+        </button>
+      {% else %}
+        <button class="btn btn-primary" type="submit" name="submit" >
+          {{ _('Add Member') }}
+        </button>
+      {% endif %}
+    </div>
+  </form>
+  {% endblock %}
+{% endblock %}
+
+{% block secondary_content %}
+{{ super() }}
+<div class="module module-narrow module-shallow">
+  <h2 class="module-heading">
+    <i class="fa fa-lg fa-info-circle"></i>
+    {{ _('What are roles?') }}
+  </h2>
+  <div class="module-content">
+    {% trans %}
+      <p><strong>Admin:</strong> Can add/edit and delete datasets, as well as
+        manage organization members.</p>
+      <p><strong>Editor:</strong> Can add and edit datasets, but not manage
+        organization members.</p>
+      <p><strong>Member:</strong> Can view the organization's private
+        datasets, but not add new datasets.</p>
+    {% endtrans %}
+  </div>
+</div>
+{% endblock %}

--- a/ckanext/portalopendatadk/templates/user/dashboard.html
+++ b/ckanext/portalopendatadk/templates/user/dashboard.html
@@ -13,7 +13,7 @@
     {% block page_header %}
       <header class="module-content page-header hug">
         <div class="content_action">
-          {% if h.user_has_admin_access(False) %}
+          {% if c.userobj.sysadmin %}
             {% link_for _('Create an Account'), controller='user', action='register', class_='btn', icon='plus' %}
           {% endif %}
           {% link_for _('Edit settings'), controller='user', action='edit', id=user.name, class_='btn', icon='cog' %}


### PR DESCRIPTION
* Only sysadmins have an access to the /user/register page.
* Removed create user button from the organization/new_member page for organization admins, it is only available for sysadmins. Organization admins can only add existing members and assign roles.
* Removed create-user button from user/dashboard page. It is only available for sysadmins only.