### PR TITLE
Fix DCAT post upgrade

### DIFF
--- a/ckanext/portalopendatadk/dcat_profile.py
+++ b/ckanext/portalopendatadk/dcat_profile.py
@@ -109,6 +109,59 @@ class DanishDCATAPProfile(RDFProfile):
     An RDF profile for the Danish DCAT-AP profile.
     """
 
+    def _publisher(self, subject, predicate):
+        """
+        Returns a dict with details about a dct:publisher entity, a foaf:Agent
+
+        Both subject and predicate must be rdflib URIRef or BNode objects
+
+        Examples:
+
+        <dct:publisher>
+            <foaf:Organization rdf:about="http://orgs.vocab.org/some-org">
+                <foaf:name>Publishing Organization for dataset 1</foaf:name>
+                <foaf:mbox>contact@some.org</foaf:mbox>
+                <foaf:homepage>http://some.org</foaf:homepage>
+                <dct:type rdf:resource="http://purl.org/adms/publishertype/NonProfitOrganisation"/>
+            </foaf:Organization>
+        </dct:publisher>
+
+        {
+            'uri': 'http://orgs.vocab.org/some-org',
+            'name': 'Publishing Organization for dataset 1',
+            'email': 'contact@some.org',
+            'url': 'http://some.org',
+            'type': 'http://purl.org/adms/publishertype/NonProfitOrganisation',
+        }
+
+        <dct:publisher rdf:resource="http://publications.europa.eu/resource/authority/corporate-body/EURCOU" />
+
+        {
+            'uri': 'http://publications.europa.eu/resource/authority/corporate-body/EURCOU'
+        }
+
+        Returns keys for uri, name, email, url and type with the values set to
+        an empty string if they could not be found
+        """
+
+        publisher = {}
+
+        for agent in self.g.objects(subject, predicate):
+
+            publisher["uri"] = (
+                str(agent) if isinstance(agent, rdflib.term.URIRef) else ""
+            )
+
+            publisher["name"] = self._object_value(agent, FOAF.name)
+
+            publisher["email"] = self._object_value(agent, FOAF.mbox)
+
+            publisher["url"] = self._object_value(agent, FOAF.homepage)
+
+            publisher["type"] = self._object_value(agent, DCT.type)
+
+        return publisher
+
     def parse_dataset(self, dataset_dict, dataset_ref):
         dataset_dict["extras"] = []
         dataset_dict["resources"] = []
@@ -179,9 +232,22 @@ class DanishDCATAPProfile(RDFProfile):
 
         # Contact details
         contact = self._contact_details(dataset_ref, DCAT.contactPoint)
+
         if not contact:
             # adms:contactPoint was supported on the first version of DCAT-AP
             contact = self._contact_details(dataset_ref, ADMS.contactPoint)
+
+        if type(contact) is list:
+            if len(contact) == 1:
+                contact = contact[0]
+            elif len(contact) > 1:
+                log.warning(
+                    "Multiple contact points found for dataset %s", dataset_ref
+                )
+                contact = self._contact_details(dataset_ref, DCAT.contactPoint)
+            elif len(contact) == 0:
+                log.warning("No contact points found for dataset %s", dataset_ref)
+                contact = self._contact_details(dataset_ref, ADMS.contactPoint)
 
         if contact:
             for key in ("uri", "name", "email"):

--- a/ckanext/portalopendatadk/plugin.py
+++ b/ckanext/portalopendatadk/plugin.py
@@ -16,11 +16,13 @@ from ckanext.portalopendatadk.views.dcat import dcat, dcat_json_interface
 from ckanext.portalopendatadk.views.documentation import doc_blueprint as documentation
 from ckanext.portalopendatadk.views.dataset import dataset
 import logging
+import json
 
 from ckanext.portalopendatadk import actions as oddk_actions
 from ckanext.portalopendatadk import auth_functions as auth
 import ckanext.portalopendatadk.helpers as oddk_helpers
 from ckanext.portalopendatadk import validators as oddk_validators
+from ckan import model
 
 _ = toolkit._
 
@@ -154,7 +156,7 @@ class PortalOpenDataDKPlugin(
 
         return pkg_dict
 
-    def before_dataset_show(self, pkg_dict):
+    def before_dataset_view(self, pkg_dict):
         data_themes = pkg_dict.get("data_themes")
         data_themes = oddk_helpers.fix_data_themes(data_themes)
 
@@ -180,6 +182,7 @@ class PortalOpenDataDKPlugin(
     def get_validators(self):
         return {
             "resource_format_validator": oddk_validators.resource_format_validator,
+            "not_empty_except_bg_jobs": oddk_validators.not_empty_except_bg_jobs,
         }
 
 

--- a/ckanext/portalopendatadk/schema/oddk_schema.yaml
+++ b/ckanext/portalopendatadk/schema/oddk_schema.yaml
@@ -90,7 +90,7 @@ dataset_fields:
   label: Author
   form_placeholder: Joe Bloggs
   display_property: dc:creator
-  validators: not_empty
+  validators: not_empty_except_bg_jobs
   dcat_field: True
 
 - field_name: author_email
@@ -99,7 +99,7 @@ dataset_fields:
   display_property: dc:creator
   display_snippet: email.html
   display_email_name_field: author
-  validators: not_empty email_validator
+  validators: not_empty_except_bg_jobs email_validator
   dcat_field: True
 
 - field_name: update_frequency

--- a/ckanext/portalopendatadk/templates/scheming/package/snippets/package_form.html
+++ b/ckanext/portalopendatadk/templates/scheming/package/snippets/package_form.html
@@ -52,4 +52,33 @@
 
 {% block metadata_fields %}
 
+{% set extras = data.extras or [] %}
+
+<div data-module="custom-fields" hidden>
+  {% for extra in extras %}
+    {% set prefix = 'extras__%d__' % loop.index0 %}
+    {{ form.custom(
+      names=(prefix ~ 'key', prefix ~ 'value', prefix ~ 'deleted'),
+      id='field-extras-%d' % loop.index,
+      label=_('Custom Field'),
+      values=(extra.key, extra.value, extra.deleted),
+      error=errors[prefix ~ 'key'] or errors[prefix ~ 'value']
+    ) }}
+  {% endfor %}
+
+  {% set total_extras = extras|count %}
+
+  {% for extra in range(total_extras, total_extras) %}
+    {% set index = loop.index0 + (extras|count) %}
+    {% set prefix = 'extras__%d__' % index %}
+    {{ form.custom(
+      names=(prefix ~ 'key', prefix ~ 'value', prefix ~ 'deleted'),
+      id='field-extras-%d' % index,
+      label=_('Custom Field'),
+      values=(extra.key, extra.value, extra.deleted),
+      error=errors[prefix ~ 'key'] or errors[prefix ~ 'value']
+    ) }}
+  {% endfor %}
+</div>
+
 {% endblock %}

--- a/ckanext/portalopendatadk/validators.py
+++ b/ckanext/portalopendatadk/validators.py
@@ -1,6 +1,12 @@
 from ckan.plugins.toolkit import Invalid, _
+from ckan.lib.navl.validators import not_empty, ignore_missing
 
 import ckanext.portalopendatadk.helpers as oddk_helpers
+
+import logging
+
+
+log = logging.getLogger(__name__)
 
 
 def resource_format_validator(value):
@@ -28,3 +34,15 @@ def language_code_validator(value):
     if value not in allowed_languages:
         raise Invalid(_("Invalid language code: {}").format(value))
     return value
+
+
+def not_empty_except_bg_jobs(key, data,
+                   errors, context):
+    """
+    Validates that a value is not empty, except when the request
+    is from a background job (e.g. harvester).
+    """
+    if not context.get('ignore_auth', False):
+        return not_empty(key, data, errors, context)
+    else:
+        return ignore_missing(key, data, errors, context)

--- a/ckanext/portalopendatadk/views/dcat.py
+++ b/ckanext/portalopendatadk/views/dcat.py
@@ -19,8 +19,7 @@ log = logging.getLogger(__name__)
 
 dcat = Blueprint(
     "dcat_oddk",
-    __name__,
-     url_prefix="/dcat"
+    __name__
 )
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Dataset form now supports adding and editing custom fields.
  - Publisher metadata (URI, name, email, URL, type) is now parsed and shown on datasets.
- Improvements
  - More robust handling of contact points (single/multiple/missing cases).
  - More reliable checksum parsing/validation for resources.
  - Resource formats normalized (e.g., OGC WFS mapped to standard code).
- Refactor
  - DCAT endpoints no longer use a fixed /dcat prefix.
- Chores
  - Validators adjusted so background jobs may skip required author fields; interactive submissions unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->